### PR TITLE
fix #6

### DIFF
--- a/dbresolver.go
+++ b/dbresolver.go
@@ -3,6 +3,7 @@ package dbresolver
 import (
 	"database/sql"
 	"errors"
+
 	"gorm.io/gorm"
 )
 

--- a/dbresolver.go
+++ b/dbresolver.go
@@ -22,10 +22,10 @@ type DBResolver struct {
 }
 
 type Config struct {
-	Sources             []gorm.Dialector
-	Replicas            []gorm.Dialector
-	Policy              Policy
-	datas               []interface{}
+	Sources  []gorm.Dialector
+	Replicas []gorm.Dialector
+	Policy   Policy
+	datas    []interface{}
 }
 
 func Register(config Config, datas ...interface{}) *DBResolver {


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [ ] Tested

### What did this pull request do?

When replicas can't use, but sources can use, `SELECT` command while be use sources. when replicas service recovery, it also use 
sources.

So, I want to add a option, control force use replicas service. Even if the replicas service is not available。

fix #6 

### User Case Description


Also mysql service is one master and more slave.

if read request very large, use sources service is very danger.
