### PR TITLE
SetConnMaxLifetime函数名更新：SetConnMaxLifeTime，相关参数同步更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Currently only the `RandomPolicy` implemented and it is the default option if no
 DB.Use(
   dbresolver.Register(dbresolver.Config{ /* xxx */ }).
   SetConnMaxIdleTime(time.Hour).
-  SetConnMaxLifetime(24 * time.Hour).
+  SetConnMaxLifeTime(8 * time.Hour).
   SetMaxIdleConns(100).
   SetMaxOpenConns(200)
 )

--- a/database.go
+++ b/database.go
@@ -22,10 +22,10 @@ func (dr *DBResolver) SetConnMaxIdleTime(d time.Duration) *DBResolver {
 
 func (dr *DBResolver) SetConnMaxLifeTime(d time.Duration) *DBResolver {
 	dr.Call(func(connPool gorm.ConnPool) error {
-		if conn, ok := connPool.(interface{ SetConnMaxLifetime(time.Duration) }); ok {
-			conn.SetConnMaxLifetime(d)
+		if conn, ok := connPool.(interface{ SetConnMaxLifeTime(time.Duration) }); ok {
+			conn.SetConnMaxLifeTime(d)
 		} else {
-			dr.DB.Logger.Error(context.Background(), "SetConnMaxLifetime not implemented for %#v", conn)
+			dr.DB.Logger.Error(context.Background(), "SetConnMaxLifeTime not implemented for %#v", conn)
 		}
 		return nil
 	})

--- a/database.go
+++ b/database.go
@@ -20,7 +20,7 @@ func (dr *DBResolver) SetConnMaxIdleTime(d time.Duration) *DBResolver {
 	return dr
 }
 
-func (dr *DBResolver) SetConnMaxLifetime(d time.Duration) *DBResolver {
+func (dr *DBResolver) SetConnMaxLifeTime(d time.Duration) *DBResolver {
 	dr.Call(func(connPool gorm.ConnPool) error {
 		if conn, ok := connPool.(interface{ SetConnMaxLifetime(time.Duration) }); ok {
 			conn.SetConnMaxLifetime(d)


### PR DESCRIPTION
SetConnMaxLifetime(24 * time.Hour) ->   SetConnMaxLifeTime(8 * time.Hour).
原因：
编译安装的 mysql 5.7  8.0 系列 连接最大时长参数（wait_timeout）为 8小时（28800秒），只有阿里云的 RDS 数据库改参数为 24小时，go程序中数据库连接的最大存活时间肯定要比数据库参数小，否则程序认为该连接是有效的，但是使用起来就会报错.
