### PR TITLE
Fix for resolving replica DB when raw SQL has leading whitespace(s)

### DIFF
--- a/callbacks.go
+++ b/callbacks.go
@@ -40,7 +40,7 @@ func (dr *DBResolver) switchGuess(db *gorm.DB) {
 	if !isTransaction(db.Statement.ConnPool) {
 		if _, ok := db.Statement.Clauses[writeName]; ok {
 			db.Statement.ConnPool = dr.resolve(db.Statement, Write)
-		} else if rawSQL := db.Statement.SQL.String(); len(rawSQL) > 10 && strings.EqualFold(rawSQL[:6], "select") && !strings.EqualFold(rawSQL[len(rawSQL)-10:], "for update") {
+		} else if rawSQL := strings.TrimSpace(db.Statement.SQL.String()); len(rawSQL) > 10 && strings.EqualFold(rawSQL[:6], "select") && !strings.EqualFold(rawSQL[len(rawSQL)-10:], "for update") {
 			db.Statement.ConnPool = dr.resolve(db.Statement, Read)
 		} else {
 			db.Statement.ConnPool = dr.resolve(db.Statement, Write)

--- a/dbresolver_test.go
+++ b/dbresolver_test.go
@@ -149,6 +149,16 @@ func TestDBResolver(t *testing.T) {
 				t.Fatalf("can't read users from read db, name %v", name)
 			}
 
+			if err := DB.Raw(" select name from users where name = ?", "9913").Row().Scan(&name); err != nil {
+				t.Fatalf("(raw sql has leading space) should go to read db, got error: %v", err)
+			}
+
+			if err := DB.Raw(`
+select name
+from users where name = ?`, "9913").Row().Scan(&name); err != nil {
+				t.Fatalf("(raw sql has leading newline) should go to read db, got error: %v", err)
+			}
+
 			if err := DB.Clauses(dbresolver.Write).Raw("select name from users where name = ?", "update").Row().Scan(&name); err != nil || name != "update" {
 				t.Fatalf("read users from write db, error %v, name %v", err, name)
 			}


### PR DESCRIPTION
Signed-off-by: Shudipta Sharma <alittleprogramming.gmail.com>

xref: https://github.com/go-gorm/dbresolver/issues/19

<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

<!--
provide a general description of the code changes in your pull request
-->

This pull request basically trim leading and trailing whitespace(s) from the raw SQL. And then resolve for replica(s).

### User Case Description

<!-- Your use case -->


While using `gorm.io/plugin/dbresolver` to split read-write, raw query having whitespace(s) as prefix should go to read server.

```go
import (
  "gorm.io/gorm"
  "gorm.io/plugin/dbresolver"
  "gorm.io/driver/mysql"
)

DB, err := gorm.Open(mysql.Open("db1_dsn"), &gorm.Config{})
if err != nil {
  // handle error
}

DB.Use(dbresolver.Register(dbresolver.Config{
  // use `db1` as sources, `db2` as replicas for 
  Sources:  []gorm.Dialector{mysql.Open("db1_dsn")},
  Replicas: []gorm.Dialector{mysql.Open("db2_dsn")}
}, "users"))


// ...

readDB, err := gorm.Open(mysql.Open("db2_dsn"), &gorm.Config{})
if err != nil {
  // handle error
}

readDB.Create(&User{Name: "read"})

// this query should go to the read db with db2_dsn
DB.Raw(`
select name from users
where name = ?
`, "read").Row().Scan(&name)

```

This query should go to the read db with `db2_dsn`, but the current dbresolver sends it to the write db with `db1_dsn`.

