### PR TITLE
feat: resolve *sql.DB based on the database context

### DIFF
--- a/dbresolver.go
+++ b/dbresolver.go
@@ -14,6 +14,7 @@ const (
 
 type DBResolver struct {
 	*gorm.DB
+	original         gorm.ConnPool
 	configs          []Config
 	resolvers        map[string]*resolver
 	global           *resolver
@@ -59,6 +60,8 @@ func (dr *DBResolver) Name() string {
 }
 
 func (dr *DBResolver) Initialize(db *gorm.DB) error {
+	dr.original = db.ConnPool
+	db.ConnPool = NewConnPool(dr.original, dr)
 	dr.DB = db
 	dr.registerCallbacks(db)
 	return dr.compile()
@@ -157,35 +160,46 @@ func (dr *DBResolver) convertToConnPool(dialectors []gorm.Dialector) (connPools 
 }
 
 func (dr *DBResolver) resolve(stmt *gorm.Statement, op Operation) gorm.ConnPool {
+	if r := dr.getResolver(stmt); r != nil {
+		return r.resolve(stmt, op)
+	}
+	return stmt.ConnPool
+}
+
+func (dr *DBResolver) getResolver(stmt *gorm.Statement) *resolver {
 	if len(dr.resolvers) > 0 {
 		if u, ok := stmt.Clauses[usingName].Expression.(using); ok && u.Use != "" {
 			if r, ok := dr.resolvers[u.Use]; ok {
-				return r.resolve(stmt, op)
+				return r
 			}
 		}
 
 		if stmt.Table != "" {
 			if r, ok := dr.resolvers[stmt.Table]; ok {
-				return r.resolve(stmt, op)
+				return r
+			}
+		}
+
+		if stmt.Model != nil {
+			if err := stmt.Parse(stmt.Model); err == nil {
+				if r, ok := dr.resolvers[stmt.Table]; ok {
+					return r
+				}
 			}
 		}
 
 		if stmt.Schema != nil {
 			if r, ok := dr.resolvers[stmt.Schema.Table]; ok {
-				return r.resolve(stmt, op)
+				return r
 			}
 		}
 
 		if rawSQL := stmt.SQL.String(); rawSQL != "" {
 			if r, ok := dr.resolvers[getTableFromRawSQL(rawSQL)]; ok {
-				return r.resolve(stmt, op)
+				return r
 			}
 		}
 	}
 
-	if dr.global != nil {
-		return dr.global.resolve(stmt, op)
-	}
-
-	return stmt.ConnPool
+	return dr.global
 }

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.14
 
 require (
 	gorm.io/driver/mysql v1.4.3
-	gorm.io/gorm v1.24.3
+	gorm.io/gorm v1.25.2-0.20230605082505-661781a3d7a3
 )

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,10 @@ github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkr
 github.com/jinzhu/now v1.1.4/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
+github.com/lzakharov/gorm v0.0.0-20230601074019-c75ecb4d9027 h1:EKUVwAfpL+gHEFUdq2UdN5muq8efwXhbaN2KmCp8CG0=
+github.com/lzakharov/gorm v0.0.0-20230601074019-c75ecb4d9027/go.mod h1:L4uxeKpfBml98NYqVqwAdmV1a2nBtAec/cf3fpucW/k=
 gorm.io/driver/mysql v1.4.3 h1:/JhWJhO2v17d8hjApTltKNADm7K7YI2ogkR7avJUL3k=
 gorm.io/driver/mysql v1.4.3/go.mod h1:sSIebwZAVPiT+27jK9HIwvsqOGKx3YMPmrA3mBJR10c=
 gorm.io/gorm v1.23.8/go.mod h1:l2lP/RyAtc1ynaTjFksBde/O8v9oOGIApu2/xRitmZk=
-gorm.io/gorm v1.24.3 h1:WL2ifUmzR/SLp85CSURAfybcHnGZ+yLSGSxgYXlFBHg=
-gorm.io/gorm v1.24.3/go.mod h1:DVrVomtaYTbqs7gB/x2uVvqnXzv0nqjB396B8cG4dBA=
+gorm.io/gorm v1.25.2-0.20230605082505-661781a3d7a3 h1:Zo7a1Lye4RHp+oNa94uO1HLX2CMoTQOBB8KozyX55Kk=
+gorm.io/gorm v1.25.2-0.20230605082505-661781a3d7a3/go.mod h1:L4uxeKpfBml98NYqVqwAdmV1a2nBtAec/cf3fpucW/k=

--- a/pool.go
+++ b/pool.go
@@ -1,0 +1,41 @@
+package dbresolver
+
+import (
+	"database/sql"
+
+	"gorm.io/gorm"
+)
+
+// ConnPool wraps original DB connection pool with database resolver.
+type ConnPool struct {
+	gorm.ConnPool
+	dr *DBResolver
+}
+
+// NewConnPool creates a new ConnPool.
+func NewConnPool(base gorm.ConnPool, dr *DBResolver) ConnPool {
+	return ConnPool{ConnPool: base, dr: dr}
+}
+
+// GetDBConnWithContext gets *sql.DB connection based on the context. If no
+// information is available, returns original connection.
+func (p ConnPool) GetDBConnWithContext(db *gorm.DB) (*sql.DB, error) {
+	if stmt := db.Statement; stmt != nil {
+		if r := p.dr.getResolver(stmt); r != nil {
+			if _, ok := db.Statement.Settings.Load(readName); ok {
+				db = p.wrap(r.resolve(stmt, Read))
+			} else if _, ok := db.Statement.Settings.Load(writeName); ok {
+				db = p.wrap(r.resolve(stmt, Write))
+			} else {
+				db = p.wrap(p.dr.original)
+			}
+
+		}
+	}
+
+	return db.DB()
+}
+
+func (ConnPool) wrap(cp gorm.ConnPool) *gorm.DB {
+	return &gorm.DB{Config: &gorm.Config{ConnPool: cp}}
+}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

This PR adds ability to resolve *sql.DB connection based on the database context. It requires https://github.com/go-gorm/gorm/pull/6366 (already in master).

### User Case Description

At this moment all these statements return the same connection pool, ignoring provided clauses:

```go
db.DB()
db.Clauses(dbresolver.Write).DB()
db.Clauses(dbresolver.Read).DB()
db.Clauses(dbresolver.Use("slow")).DB()
// etc
```

However, it should return different connections based on the current database state. See more cases inside `TestConnPool`.