### PR TITLE
feat: impl clause.Interface for using

### DIFF
--- a/clauses.go
+++ b/clauses.go
@@ -58,3 +58,11 @@ func (u using) ModifyStatement(stmt *gorm.Statement) {
 // Build implements clause.Expression interface
 func (u using) Build(clause.Builder) {
 }
+
+// Name implements clause.Interface interface
+func (u using) Name() string {
+	return usingName
+}
+
+// MergeClause implements clause.Interface interface
+func (u using) MergeClause(*clause.Clause) {}


### PR DESCRIPTION
<!--
Make sure these boxes checked before submitting your pull request.

For significant changes, please open an issue to make an agreement on an implementation design/plan first before starting it.
-->

- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

impl clause.Interface for using

### User Case Description

see https://github.com/go-gorm/gen/issues/982

#117 

如果我想要让 `Clauses(dbresolver.Use("db_1")` 可以正常被使用，需要让 `dbresolver.using` 实现 `clause.Interface` 接口

If I want 'Clauses(dbresolver.Use("db_1")' to be used normally, I need 'dbresolver.using' to implement the clause.Interface 'interface

