### PR TITLE
feat(policy): Added `RoundRobinPolicy` and `PolicyFunc`

### DIFF
--- a/policy.go
+++ b/policy.go
@@ -10,9 +10,23 @@ type Policy interface {
 	Resolve([]gorm.ConnPool) gorm.ConnPool
 }
 
+type PolicyFunc func([]gorm.ConnPool) gorm.ConnPool
+
+func (f PolicyFunc) Resolve(connPools []gorm.ConnPool) gorm.ConnPool {
+	return f(connPools)
+}
+
 type RandomPolicy struct {
 }
 
 func (RandomPolicy) Resolve(connPools []gorm.ConnPool) gorm.ConnPool {
 	return connPools[rand.Intn(len(connPools))]
+}
+
+func RoundRobinPolicy() Policy {
+	var i int
+	return PolicyFunc(func(connPools []gorm.ConnPool) gorm.ConnPool {
+		i = (i + 1) % len(connPools)
+		return connPools[i]
+	})
 }

--- a/policy_test.go
+++ b/policy_test.go
@@ -23,7 +23,7 @@ func TestPolicy_RoundRobinPolicy(t *testing.T) {
 			p = p3
 		}
 		if p != RoundRobinPolicy().Resolve(pools) {
-			t.Errorf("RandomPolicy should return p1")
+			t.Errorf("RandomPolicy should return %v", p)
 		}
 	}
 }

--- a/policy_test.go
+++ b/policy_test.go
@@ -6,7 +6,7 @@ import (
 	"gorm.io/gorm"
 )
 
-func TestPolicy_PolicyFunc(t *testing.T) {
+func TestPolicy_RoundRobinPolicy(t *testing.T) {
 	var p1, p2, p3 gorm.ConnPool
 	var pools = []gorm.ConnPool{
 		p1, p2, p3,

--- a/policy_test.go
+++ b/policy_test.go
@@ -13,17 +13,9 @@ func TestPolicy_RoundRobinPolicy(t *testing.T) {
 	}
 
 	for i := 0; i < 10; i++ {
-		var p gorm.ConnPool
-		switch i % 3 {
-		case 0:
-			p = p1
-		case 1:
-			p = p2
-		case 2:
-			p = p3
+		if pools[i%3] != RoundRobinPolicy().Resolve(pools) {
+			t.Errorf("RoundRobinPolicy failed")
 		}
-		if p != RoundRobinPolicy().Resolve(pools) {
-			t.Errorf("RandomPolicy should return %v", p)
-		}
+
 	}
 }

--- a/policy_test.go
+++ b/policy_test.go
@@ -1,0 +1,29 @@
+package dbresolver
+
+import (
+	"testing"
+
+	"gorm.io/gorm"
+)
+
+func TestPolicy_PolicyFunc(t *testing.T) {
+	var p1, p2, p3 gorm.ConnPool
+	var pools = []gorm.ConnPool{
+		p1, p2, p3,
+	}
+
+	for i := 0; i < 10; i++ {
+		var p gorm.ConnPool
+		switch i % 3 {
+		case 0:
+			p = p1
+		case 1:
+			p = p2
+		case 2:
+			p = p3
+		}
+		if p != RoundRobinPolicy().Resolve(pools) {
+			t.Errorf("RandomPolicy should return p1")
+		}
+	}
+}


### PR DESCRIPTION
- [x] Do only one thing
- [x] Non breaking API changes
- [x] Tested

### What did this pull request do?

- feature 1: Added `RoundRobinPolicy` - support for using a round-robin mechanism for slave allocation.
- feature 2: Added `PolicyFunc` - support for customizing a function to implement a policy


### User Case Description

```go
dbresolver.Config{
	Policy: dbresolver.RoundRobinPolicy(),
}

dbresolver.Config{
	Policy: dbresolver.PolicyFunc(func([]dbresolver.ConnPool) dbresolver.ConnPool {
		// do something
	}),
}
```

### The Test Result

```bash
=== RUN   TestPolicy_PolicyFunc
--- PASS: TestPolicy_PolicyFunc (0.00s)
PASS
```
