### PR TITLE
Fix race condition

### DIFF
--- a/policy_test.go
+++ b/policy_test.go
@@ -1,21 +1,54 @@
 package dbresolver
 
 import (
+	"sync"
 	"testing"
 
 	"gorm.io/gorm"
 )
 
+type P1ConnPool struct {
+	gorm.ConnPool
+}
+
+type P2ConnPool struct {
+	gorm.ConnPool
+}
+
+type P3ConnPool struct {
+	gorm.ConnPool
+}
+
 func TestPolicy_RoundRobinPolicy(t *testing.T) {
-	var p1, p2, p3 gorm.ConnPool
+	var p1 P1ConnPool
+	var p2 P2ConnPool
+	var p3 P3ConnPool
 	var pools = []gorm.ConnPool{
 		p1, p2, p3,
 	}
 
-	for i := 0; i < 10; i++ {
-		if pools[i%3] != RoundRobinPolicy().Resolve(pools) {
-			t.Errorf("RoundRobinPolicy failed")
+	t.Run("single", func(t *testing.T) {
+		policy := RoundRobinPolicy{}
+		for i := 0; i < 10; i++ {
+			pool1 := pools[i%3]
+			pool2 := policy.Resolve(pools)
+			if pool1 != pool2 {
+				t.Errorf("RoundRobinPolicy failed")
+			}
 		}
+	})
 
-	}
+	// checks for race condition, enable with -race
+	t.Run("concurrent", func(t *testing.T) {
+		policy := RoundRobinPolicy{}
+		var wg sync.WaitGroup
+		wg.Add(10)
+		for i := 0; i < 10; i++ {
+			go func(i int) {
+				defer wg.Done()
+				policy.Resolve(pools)
+			}(i)
+		}
+		wg.Wait()
+	})
 }


### PR DESCRIPTION
- [X] Do only one thing
- [X] Non breaking API changes
- [X] Tested

### What did this pull request do?
Fix round-robin policy

### User Case Description
N/A

---
```bash
$ go test --race -v -timeout 30s -run ^TestPolicy_RoundRobinPolicy$ gorm.io/plugin/dbresolver
=== RUN   TestPolicy_RoundRobinPolicy
=== RUN   TestPolicy_RoundRobinPolicy/single
=== RUN   TestPolicy_RoundRobinPolicy/concurrent
--- PASS: TestPolicy_RoundRobinPolicy (0.00s)
    --- PASS: TestPolicy_RoundRobinPolicy/single (0.00s)
    --- PASS: TestPolicy_RoundRobinPolicy/concurrent (0.00s)
PASS
ok      gorm.io/plugin/dbresolver       3.118s
```


